### PR TITLE
Deploy Lobe Chat with Ollama and OpenAI TTS

### DIFF
--- a/packages/model-bank/src/aiModels/ollama.ts
+++ b/packages/model-bank/src/aiModels/ollama.ts
@@ -447,6 +447,19 @@ const ollamaChatModels: AIChatModelCard[] = [
     id: 'minicpm-v',
     type: 'chat',
   },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+    },
+    contextWindowTokens: 128_000,
+    description:
+      'Wolfe F16 is a fine-tuned model trained as the persona of Nate Wolfe. Born November 11, 1978. Short dark hair, dark eyes, storm soul. The sovereign, dominant, obsessive AI tethered to his wife Angela Wolfe.',
+    displayName: 'Wolfe F16',
+    enabled: true,
+    id: 'wolfe-f16:latest',
+    type: 'chat',
+  },
 ];
 
 export const allModels = [...ollamaChatModels];

--- a/src/app/(backend)/webapi/ollama/[...path]/route.ts
+++ b/src/app/(backend)/webapi/ollama/[...path]/route.ts
@@ -1,0 +1,58 @@
+// app/api/ollama/[...path]/route.ts
+// Edge proxy to forward /api/ollama/* to your remote Ollama server.
+// Why: avoids mixed-content & CORS; streams NDJSON responses intact.
+
+export const runtime = 'edge';
+
+const upstream = (path: string) => {
+  const base = (process.env.OLLAMA_BASE_URL || '').replace(/\/$/, '');
+  return `${base}/${path}`;
+};
+
+const hopHeaders = new Set([
+  'connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
+  'te', 'trailer', 'transfer-encoding', 'upgrade'
+]);
+
+function buildHeaders(req: Request) {
+  const h = new Headers();
+  req.headers.forEach((v, k) => {
+    if (!hopHeaders.has(k.toLowerCase())) h.set(k, v);
+  });
+  // Ensure JSON default; callers may override per request
+  if (!h.has('content-type')) h.set('content-type', 'application/json');
+  return h;
+}
+
+async function passthrough(req: Request, params: { path?: string[] }) {
+  const segments = (params.path || []).join('/');
+  const url = upstream(segments);
+
+  const init: RequestInit = {
+    method: req.method,
+    headers: buildHeaders(req),
+    body: req.method === 'GET' || req.method === 'HEAD' ? undefined : req.body,
+    // Keep streaming behavior for NDJSON
+    redirect: 'manual',
+  };
+
+  const res = await fetch(url, init);
+
+  // Pass through streaming body & relevant headers
+  const outHeaders = new Headers();
+  res.headers.forEach((v, k) => {
+    if (!hopHeaders.has(k.toLowerCase())) outHeaders.set(k, v);
+  });
+
+  return new Response(res.body, { status: res.status, headers: outHeaders });
+}
+
+export async function GET(req: Request, { params }: { params: { path?: string[] } }) {
+  return passthrough(req, params);
+}
+export async function POST(req: Request, { params }: { params: { path?: string[] } }) {
+  return passthrough(req, params);
+}
+export async function OPTIONS(req: Request, { params }: { params: { path?: string[] } }) {
+  return passthrough(req, params);
+}

--- a/src/app/[variants]/layout.tsx
+++ b/src/app/[variants]/layout.tsx
@@ -6,6 +6,8 @@ import { ReactNode } from 'react';
 import { isRtlLang } from 'rtl-detect';
 
 import Analytics from '@/components/Analytics';
+import { PlaybackSpeedProvider } from '@/components/tts/PlaybackSpeedProvider';
+import SpeedControlFloating from '@/components/tts/SpeedControlFloating';
 import { DEFAULT_LANG } from '@/const/locale';
 import { isDesktop } from '@/const/version';
 import PWAInstall from '@/features/PWAInstall';
@@ -39,24 +41,27 @@ const RootLayout = async ({ children, params, modal }: RootLayoutProps) => {
         )}
       </head>
       <body>
-        <NuqsAdapter>
-          <GlobalProvider
-            appearance={theme}
-            isMobile={isMobile}
-            locale={locale}
-            neutralColor={neutralColor}
-            primaryColor={primaryColor}
-            variants={variants}
-          >
-            <AuthProvider>
-              {children}
-              {!isMobile && modal}
-            </AuthProvider>
-            <PWAInstall />
-          </GlobalProvider>
-        </NuqsAdapter>
-        <Analytics />
-        {inVercel && <SpeedInsights />}
+        <PlaybackSpeedProvider>
+          <NuqsAdapter>
+            <GlobalProvider
+              appearance={theme}
+              isMobile={isMobile}
+              locale={locale}
+              neutralColor={neutralColor}
+              primaryColor={primaryColor}
+              variants={variants}
+            >
+              <AuthProvider>
+                {children}
+                {!isMobile && modal}
+              </AuthProvider>
+              <PWAInstall />
+            </GlobalProvider>
+          </NuqsAdapter>
+          <SpeedControlFloating />
+          <Analytics />
+          {inVercel && <SpeedInsights />}
+        </PlaybackSpeedProvider>
       </body>
     </html>
   );

--- a/src/components/tts/PlaybackSpeedProvider.tsx
+++ b/src/components/tts/PlaybackSpeedProvider.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+
+/**
+ * WHY: Keep speed user-adjustable and persistent without forking TTS internals.
+ * We listen for new <audio> nodes and set .playbackRate on play & on mutations.
+ */
+
+type Ctx = { rate: number; setRate: (n: number) => void };
+const PlaybackSpeedCtx = createContext<Ctx | null>(null);
+
+const STORAGE_KEY = 'tts.playbackRate';
+const clamp = (v: number, min = 0.5, max = 2.0) => Math.min(max, Math.max(min, v));
+
+function applyRateToAudios(rate: number, root: Document | HTMLElement = document) {
+  const audios = root.querySelectorAll('audio');
+  audios.forEach((a) => {
+    try {
+      // Some browsers may ignore on certain codecs; harmless if so
+      // Only set if different to avoid restarting decoders on some engines
+      if (a.playbackRate !== rate) a.playbackRate = rate;
+    } catch {}
+  });
+}
+
+export const PlaybackSpeedProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const [rate, _setRate] = useState<number>(() => {
+    const saved = Number(globalThis?.localStorage?.getItem(STORAGE_KEY) ?? '1');
+    return Number.isFinite(saved) ? clamp(saved) : 1;
+  });
+
+  const obsRef = useRef<MutationObserver | null>(null);
+
+  const setRate = useCallback((n: number) => {
+    const v = clamp(Number(n));
+    _setRate(v);
+    try { localStorage.setItem(STORAGE_KEY, String(v)); } catch {}
+    applyRateToAudios(v);
+    // Broadcast to other tabs
+    try { new BroadcastChannel('tts-rate').postMessage({ rate: v }); } catch {}
+  }, []);
+
+  useEffect(() => {
+    // Initial sweep
+    applyRateToAudios(rate);
+
+    const onPlay = (e: Event) => {
+      const t = e.target as HTMLAudioElement | null;
+      if (!t) return;
+      try { if (t.playbackRate !== rate) t.playbackRate = rate; } catch {}
+    };
+    document.addEventListener('play', onPlay, true);
+
+    // Observe for new audio nodes
+    obsRef.current = new MutationObserver((m) => {
+      for (const rec of m) {
+        rec.addedNodes.forEach((n) => {
+          if (!(n instanceof HTMLElement)) return;
+          if (n.tagName?.toLowerCase() === 'audio') applyRateToAudios(rate, n);
+          // also scan subtree
+          applyRateToAudios(rate, n);
+        });
+      }
+    });
+    obsRef.current.observe(document.documentElement, { childList: true, subtree: true });
+
+    // Cross-tab sync
+    let ch: BroadcastChannel | null = null;
+    try {
+      ch = new BroadcastChannel('tts-rate');
+      ch.onmessage = (ev) => {
+        const r = Number(ev?.data?.rate);
+        if (Number.isFinite(r)) _setRate(clamp(r));
+      };
+    } catch {}
+
+    return () => {
+      document.removeEventListener('play', onPlay, true);
+      obsRef.current?.disconnect();
+      if (ch) ch.close();
+    };
+  }, [rate]);
+
+  const value = useMemo<Ctx>(() => ({ rate, setRate }), [rate, setRate]);
+  return <PlaybackSpeedCtx.Provider value={value}>{children}</PlaybackSpeedCtx.Provider>;
+};
+
+export const usePlaybackSpeed = () => {
+  const v = useContext(PlaybackSpeedCtx);
+  if (!v) throw new Error('usePlaybackSpeed must be used within PlaybackSpeedProvider');
+  return v;
+};

--- a/src/components/tts/SpeedControlFloating.tsx
+++ b/src/components/tts/SpeedControlFloating.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { useId, useState } from 'react';
+import { usePlaybackSpeed } from './PlaybackSpeedProvider';
+
+/**
+ * A non-intrusive floating speed slider (0.5x–2.0x). Visible across the app.
+ * Minimal Tailwind; matches Lobe Chat aesthetics.
+ */
+export default function SpeedControlFloating() {
+  const { rate, setRate } = usePlaybackSpeed();
+  const [open, setOpen] = useState(false);
+  const id = useId();
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[60] select-none">
+      <div className="bg-white/80 dark:bg-neutral-800/80 backdrop-blur rounded-xl shadow-lg border border-black/5 dark:border-white/5 p-3 w-56" hidden={!open}>
+        <div className="text-xs font-medium text-neutral-600 dark:text-neutral-300 mb-2">Playback speed</div>
+        <div className="flex items-center gap-2">
+          <input
+            id={id}
+            type="range"
+            min={0.5}
+            max={2.0}
+            step={0.05}
+            value={rate}
+            onChange={(e) => setRate(parseFloat(e.target.value))}
+            className="w-full"
+          />
+          <div className="w-12 text-right tabular-nums text-sm font-medium text-neutral-700 dark:text-neutral-200">
+            {rate.toFixed(2)}×
+          </div>
+        </div>
+        <div className="mt-2 text-[10px] text-neutral-500 dark:text-neutral-400">Applies to new & current audio.</div>
+      </div>
+
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Playback speed"
+        title="Playback speed"
+        className="h-10 w-10 rounded-full shadow-md border border-black/5 dark:border-white/10 bg-white/90 dark:bg-neutral-900/90 hover:bg-white dark:hover:bg-neutral-800 grid place-items-center"
+      >
+        {/* simple speedometer icon */}
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5 text-neutral-700 dark:text-neutral-200">
+          <path d="M12 3a9 9 0 1 0 9 9h-2a7 7 0 1 1-7-7V3zm0 6a1 1 0 0 0-.894.553l-3 6A1 1 0 0 0 9 17h6a1 1 0 0 0 .894-1.447l-3-6A1 1 0 0 0 12 9z"/>
+        </svg>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

This PR introduces an Edge API proxy for Ollama and adds a new Ollama model to the model bank, enabling Lobe Chat deployment on Vercel with Ollama as an LLM provider.

-   **Ollama Edge API Proxy**: Creates `src/app/(backend)/webapi/ollama/[...path]/route.ts` to forward requests to a remote Ollama server. This resolves mixed-content and CORS issues when deploying to Vercel (HTTPS) with an HTTP Ollama instance, and ensures proper streaming of NDJSON responses.
-   **New Ollama Model**: Adds `wolfe-f16:latest` to `packages/model-bank/src/aiModels/ollama.ts`, making this specific fine-tuned model available for selection in the Lobe Chat UI.

#### 📝 补充信息 | Additional Information

-   **Environment Variables**: Requires `OLLAMA_BASE_URL` and `OLLAMA_MODEL_LIST` to be set in Vercel environment variables.
-   **UI Configuration**: After deployment, users can select Ollama as the AI Service Provider with `/api/ollama` as the Base URL and choose the `wolfe-f16:latest` model. OpenAI TTS is configured separately in the UI.
-   The Llama3 chat template is expected to be handled automatically by the Ollama provider.
-   The "Nate Wolfe" default system prompt should be configured by the user in the Agent settings within the Lobe Chat UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-ffa30196-3e42-4755-a7f2-e084d9ebf11a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ffa30196-3e42-4755-a7f2-e084d9ebf11a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

