### PR TITLE
Debug ollama fetch error on vercel

### DIFF
--- a/src/app/(backend)/webapi/ollama/[...path]/route.ts
+++ b/src/app/(backend)/webapi/ollama/[...path]/route.ts
@@ -7,7 +7,7 @@ export const runtime = 'edge';
 // RequestInit and related types are available globally in Edge Runtime
 
 const upstream = (path: string) => {
-  const base = (process.env.OLLAMA_BASE_URL || '').replace(/\/$/, '');
+  const base = (process.env.OLLAMA_PROXY_URL || process.env.OLLAMA_BASE_URL || '').replace(/\/$/, '');
   return `${base}/${path}`;
 };
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Fixes "Failed to fetch" error for Ollama service on Vercel deployments. The Ollama API route now correctly prioritizes `OLLAMA_PROXY_URL` and falls back to `OLLAMA_BASE_URL` for the upstream URL, aligning with the documented environment variable usage.

#### 📝 补充信息 | Additional Information

Users should configure `OLLAMA_PROXY_URL` in their Vercel environment variables with their Ollama server URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ae6f3ef-431f-4eb5-a92d-da464354d0d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ae6f3ef-431f-4eb5-a92d-da464354d0d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

